### PR TITLE
Allow newer requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - 3.3
     - 3.4
     
-install: "pip install -r requirements.txt"
+install: "pip install -e ."
 
 script:
  - python test.py

--- a/python_translate/requirements.txt
+++ b/python_translate/requirements.txt
@@ -1,3 +1,0 @@
-slimit==0.8.1
-PyYAML==3.11
-codegen==1.0

--- a/python_translate/tests/fixtures/resources.po
+++ b/python_translate/tests/fixtures/resources.po
@@ -1,4 +1,4 @@
-# 
+#
 msgid ""
 msgstr ""
 "Language: en\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-PyYAML==3.11
-polib==1.0.6
-codegen==1.0
-

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ setup(
 
     # Dependent packages (distributions)
     install_requires=[
-        "PyYAML==3.11",
-        "codegen==1.0",
-        "polib==1.0.6"
+        "PyYAML>=3.11",
+        "codegen>=1.0",
+        "polib>=1.0.6"
     ],
 )


### PR DESCRIPTION
Instead of pinning requirements to a specific version, allow newer
versions as well. Also remove unnecessary `requirement.txt` files.

Fixes #2